### PR TITLE
Changed implementation to remove listener because of deprecated method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,10 @@ const index = () => {
 	};
 
 	useEffect(() => {
-		AppState.addEventListener("change", onAppStateChange);
+		const listener = AppState.addEventListener("change", onAppStateChange);
 
 		return () => {
-			AppState.removeEventListener("change", onAppStateChange);
+			listener.remove()
 		};
 	}, []);
 


### PR DESCRIPTION
removeEventListener method from react-native appstate is marked as deprecated and this PR fixes the problem by following the new intended way of removing listeners.